### PR TITLE
compare buffer bytes directly for faster detection

### DIFF
--- a/bench/index.ts
+++ b/bench/index.ts
@@ -28,9 +28,10 @@ const ONE_BILLION = 1000000000
 
 const fixtures = path.resolve(__dirname, '../test/fixtures')
 
-// Load all PNG images in test/fixtures.
-let files = fs.readdirSync(fixtures)
-files = files.filter(function (f) { return f.endsWith('.png') })
+// Specify the images in test/fixtures to use for benchmarking.
+const files: string[] = [
+  '304x85.png'
+]
 
 // Create a benchmark for each image.
 const benchmarks: any[] = []

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,14 +61,25 @@ function measurePNG (header: Buffer): Result {
 // detect returns the file format of the given header buffer. Format.UNKNOWN is
 // returned if the file type is not supported.
 function detect (header: Buffer): Format {
-  if (ascii(header, 1, 8) === 'PNG\r\n\x1a\n' && ascii(header, 12, 16) === 'IHDR') {
+  // PNG
+  if (
+    // _PNG\r\n\x1a\n
+    header[0] === 0x89 &&
+    header[1] === 0x50 &&
+    header[2] === 0x4e &&
+    header[3] === 0x47 &&
+    header[4] === 0x0d &&
+    header[5] === 0x0a &&
+    header[6] === 0x1a &&
+    header[7] === 0x0a &&
+    // IHDR
+    header[12] === 0x49 &&
+    header[13] === 0x48 &&
+    header[14] === 0x44 &&
+    header[15] === 0x52
+  ) {
     return Format.PNG
   }
-  return Format.UNKNOWN
-}
 
-// ascii returns an ASCII string represented by the bytes in b from the start to
-// end indexes.
-function ascii (b: Buffer, start: number, end: number): string {
-  return b.toString('ascii', start, end)
+  return Format.UNKNOWN
 }


### PR DESCRIPTION
#### compare buffer bytes directly for faster detection

Previously, in order to detect the type of the file, the buffer was
converted to ASCII strings and then compared to hard-coded strings. Now,
the bytes of the buffer are compared directly to hard-coded bytes, which
is more efficient.

    name                        old time/op  new time/op  delta
    Calipers/png-304x85         90.9µs ± 3%  85.6µs ± 3%   -5.85%  (p=0.008 n=5+5)
    Calipers/png-304x85-buffer  2.14µs ± 8%  1.29µs ± 3%  -39.67%  (p=0.008 n=5+5)

#### reduce number of benchmark cases

Previously the benchmark script ran a benchmark for each PNG file in
`test/fixtures`. The measurements for all PNGs were roughly the same, so
running a benchmark for each seems redundant. It was also time
consuming. Now, only a single PNG is benchmarked.
