### PR TITLE
fix(Buffer): Update buffer init call

### DIFF
--- a/lib/detect.js
+++ b/lib/detect.js
@@ -8,7 +8,7 @@ var DETECT_LENGTH = 16;
 
 //Determines the appropriate plugin to use for the given file descriptor.
 module.exports = function (fd, plugins) {
-  return pread(fd, new Buffer(DETECT_LENGTH), 0, DETECT_LENGTH, 0)
+  return pread(fd, Buffer.alloc(DETECT_LENGTH), 0, DETECT_LENGTH, 0)
   .spread(function (bytesRead, buffer) {
     for (var i = 0; i < plugins.length; i++) {
       var plugin = plugins[i];


### PR DESCRIPTION
- `new Buffer()` is deprecated in favor of Buffer.x, in this case `Buffer.alloc()`