### PR TITLE
feat(Bluebird Removal): Remove bluebird from detect.test

### DIFF
--- a/test/detect.test.js
+++ b/test/detect.test.js
@@ -6,18 +6,18 @@ var util = require('util');
 var popen   = util.promisify(fs.open);
 var detect  = require('../lib/detect');
 
-describe('detect', function () {
+describe('detect', () => {
 
   var txtPath = path.resolve(__dirname, 'fixtures/file.txt');
 
   var fakeTruePlugin = {
-    detect: function (buffer) {
+    detect: (buffer) => {
       return buffer.toString('ascii', 0, 12) === 'A text file.';
     }
   };
 
   var fakeFalsePlugin = {
-    detect: function () {
+    detect: () => {
       return false;
     }
   };

--- a/test/detect.test.js
+++ b/test/detect.test.js
@@ -2,8 +2,8 @@
 
 var fs      = require('fs');
 var path    = require('path');
-var Promise = require('bluebird');
-var popen   = Promise.promisify(fs.open);
+var util = require('util');
+var popen   = util.promisify(fs.open);
 var detect  = require('../lib/detect');
 
 describe('detect', function () {
@@ -22,21 +22,15 @@ describe('detect', function () {
     }
   };
 
-  it('should return the first plugin that returns true', function () {
-    return popen(txtPath, 'r')
-    .then(function (fd) {
-      return detect(fd, [fakeFalsePlugin, fakeTruePlugin]);
-    })
-    .then(function (plugin) {
-      expect(plugin).toBe(fakeTruePlugin);
-    });
+  it('should return the first plugin that returns true', async () => {
+    const fd = await popen(txtPath, 'r');
+    const plugin = await detect(fd, [fakeFalsePlugin, fakeTruePlugin]);
+    expect(plugin).toBe(fakeTruePlugin);
   });
 
-  it('should throw an error for an unsupported file type', function () {
-    return popen(txtPath, 'r')
-    .then(function (fd) {
-      return expect(detect(fd, [fakeFalsePlugin])).rejects.toThrow(Error);
-    });
+  it('should throw an error for an unsupported file type', async () => {
+    const fd = await popen(txtPath, 'r');
+    expect(detect(fd, [fakeFalsePlugin])).rejects.toThrow(Error);
   });
 
 });


### PR DESCRIPTION
## Description
* Ngl forgot to remove bluebird from the test cases but a separate PR shall suffice. 
* Replaces then chain with async/await for better readability