### PR TITLE
fix(Readme): Update readme to account for new dependencies needed to run on linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ To install Poppler on Ubuntu:
 ```
 apt-get install pkg-config
 apt-get install libpoppler-cpp-dev
+apt-get install libpoppler-private-dev
+apt-get install g++
 ```
 
 # Usage

--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ To install Poppler on Ubuntu:
 apt-get install pkg-config
 apt-get install libpoppler-cpp-dev
 apt-get install libpoppler-private-dev
-apt-get install g++
 ```
 
 # Usage


### PR DESCRIPTION
- `libpoppler-private-dev` is needed to run calipers on ubuntu